### PR TITLE
Load image from classpath, not filesystem

### DIFF
--- a/DrawPanel.java
+++ b/DrawPanel.java
@@ -33,7 +33,7 @@ public class DrawPanel extends JPanel{
 
             // Rememember to rightclick src New -> Package -> name: pics -> MOVE *.jpg to pics.
             // if you are starting in IntelliJ.
-            volvoImage = ImageIO.read(new File(String.join(File.separator, "pics", "Volvo240.jpg"));
+            volvoImage = ImageIO.read(DrawPanel.class.getResourceFromStream("pics/Volvo240.jpg"));
         } catch (IOException ex)
         {
             ex.printStackTrace();


### PR DESCRIPTION
The previous version doesn't support jar-ing or other classpath stuff.